### PR TITLE
Clarify a variable type.

### DIFF
--- a/ares_process.c
+++ b/ares_process.c
@@ -407,7 +407,7 @@ static void read_udp_packets(ares_channel channel, fd_set *read_fds,
   ssize_t count;
   unsigned char buf[MAXENDSSZ + 1];
 #ifdef HAVE_RECVFROM
-  ares_socklen_t fromlen;
+  socklen_t fromlen;
   union {
     struct sockaddr     sa;
     struct sockaddr_in  sa4;


### PR DESCRIPTION
Calling 'recvfrom()' on ares_process.c, pass the right argument type to parameter.

I found this from node.js project. This is the link:
https://github.com/joyent/node/pull/7859#issuecomment-47453657