### PR TITLE
Replace LoadLibrary by LoadLibraryW

### DIFF
--- a/ares_library_init.c
+++ b/ares_library_init.c
@@ -45,7 +45,7 @@ static int ares_win32_init(void)
 #ifdef USE_WINSOCK
 
   hnd_iphlpapi = 0;
-  hnd_iphlpapi = LoadLibrary("iphlpapi.dll");
+  hnd_iphlpapi = LoadLibraryW(L"iphlpapi.dll");
   if (!hnd_iphlpapi)
     return ARES_ELOADIPHLPAPI;
 
@@ -73,7 +73,7 @@ static int ares_win32_init(void)
    */
 
   hnd_advapi32 = 0;
-  hnd_advapi32 = LoadLibrary("advapi32.dll");
+  hnd_advapi32 = LoadLibraryW(L"advapi32.dll");
   if (hnd_advapi32)
     {
       ares_fpSystemFunction036 = (fpSystemFunction036_t)


### PR DESCRIPTION
On Windows, when compiling with `UNICODE` defined, `LoadLibrary` becomes `LoadLibraryW`. When an ASCII string is passed to that function it crashes.

See https://github.com/iojs/io.js/pull/226 for more discussions on this.